### PR TITLE
Fix static OTP not working on repeated logins for demo users

### DIFF
--- a/drfpasswordless/utils.py
+++ b/drfpasswordless/utils.py
@@ -1,14 +1,15 @@
 import logging
 import os
+
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
 from django.template import loader
 from django.utils import timezone
+
 from drfpasswordless.authtoken.models import Token
 from drfpasswordless.models import CallbackToken
 from drfpasswordless.settings import api_settings
-
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
@@ -16,7 +17,9 @@ User = get_user_model()
 
 def authenticate_by_token(callback_token):
     try:
-        token = CallbackToken.objects.get(key=callback_token, is_active=True, type=CallbackToken.TOKEN_TYPE_AUTH)
+        token = CallbackToken.objects.get(
+            key=callback_token, is_active=True, type=CallbackToken.TOKEN_TYPE_AUTH
+        )
 
         # Returning a user designates a successful authentication.
         token.user = User.objects.get(pk=token.user.pk)
@@ -26,7 +29,9 @@ def authenticate_by_token(callback_token):
         return token.user
 
     except CallbackToken.DoesNotExist:
-        logger.debug("drfpasswordless: Challenged with a callback token that doesn't exist.")
+        logger.debug(
+            "drfpasswordless: Challenged with a callback token that doesn't exist."
+        )
     except User.DoesNotExist:
         logger.debug("drfpasswordless: Authenticated user somehow doesn't exist.")
     except PermissionDenied:
@@ -38,9 +43,11 @@ def authenticate_by_token(callback_token):
 def create_callback_token_for_user(user, alias_type, token_type):
     token = None
     alias_type_u = alias_type.upper()
-    to_alias_field = getattr(api_settings, f'PASSWORDLESS_USER_{alias_type_u}_FIELD_NAME')
+    to_alias_field = getattr(
+        api_settings, f"PASSWORDLESS_USER_{alias_type_u}_FIELD_NAME"
+    )
     if user.pk in api_settings.PASSWORDLESS_DEMO_USERS.keys():
-        token = CallbackToken.objects.filter(user=user).first()
+        token = CallbackToken.objects.filter(user=user, is_active=True).first()
         if token:
             return token
         else:
@@ -49,15 +56,15 @@ def create_callback_token_for_user(user, alias_type, token_type):
                 key=api_settings.PASSWORDLESS_DEMO_USERS[user.pk],
                 to_alias_type=alias_type_u,
                 to_alias=getattr(user, to_alias_field),
-                type=token_type
+                type=token_type,
             )
-    
-    token = CallbackToken.objects.create(user=user,
-                                            to_alias_type=alias_type_u,
-                                            to_alias=getattr(user, to_alias_field),
-                                            type=token_type)
 
-
+    token = CallbackToken.objects.create(
+        user=user,
+        to_alias_type=alias_type_u,
+        to_alias=getattr(user, to_alias_field),
+        type=token_type,
+    )
 
     if token is not None:
         return token
@@ -93,12 +100,20 @@ def verify_user_alias(user, token):
     """
     Marks a user's contact point as verified depending on accepted token type.
     """
-    if token.to_alias_type == 'EMAIL':
-        if token.to_alias == getattr(user, api_settings.PASSWORDLESS_USER_EMAIL_FIELD_NAME):
-            setattr(user, api_settings.PASSWORDLESS_USER_EMAIL_VERIFIED_FIELD_NAME, True)
-    elif token.to_alias_type == 'MOBILE':
-        if token.to_alias == getattr(user, api_settings.PASSWORDLESS_USER_MOBILE_FIELD_NAME):
-            setattr(user, api_settings.PASSWORDLESS_USER_MOBILE_VERIFIED_FIELD_NAME, True)
+    if token.to_alias_type == "EMAIL":
+        if token.to_alias == getattr(
+            user, api_settings.PASSWORDLESS_USER_EMAIL_FIELD_NAME
+        ):
+            setattr(
+                user, api_settings.PASSWORDLESS_USER_EMAIL_VERIFIED_FIELD_NAME, True
+            )
+    elif token.to_alias_type == "MOBILE":
+        if token.to_alias == getattr(
+            user, api_settings.PASSWORDLESS_USER_MOBILE_FIELD_NAME
+        ):
+            setattr(
+                user, api_settings.PASSWORDLESS_USER_MOBILE_VERIFIED_FIELD_NAME, True
+            )
     else:
         return False
     user.save()
@@ -126,33 +141,48 @@ def send_email_with_callback_token(user, email_token, **kwargs):
             # Make sure we have a sending address before sending.
 
             # Get email subject and message
-            email_subject = kwargs.get('email_subject',
-                                       api_settings.PASSWORDLESS_EMAIL_SUBJECT)
-            email_plaintext = kwargs.get('email_plaintext',
-                                         api_settings.PASSWORDLESS_EMAIL_PLAINTEXT_MESSAGE)
-            email_html = kwargs.get('email_html',
-                                    api_settings.PASSWORDLESS_EMAIL_TOKEN_HTML_TEMPLATE_NAME)
+            email_subject = kwargs.get(
+                "email_subject", api_settings.PASSWORDLESS_EMAIL_SUBJECT
+            )
+            email_plaintext = kwargs.get(
+                "email_plaintext", api_settings.PASSWORDLESS_EMAIL_PLAINTEXT_MESSAGE
+            )
+            email_html = kwargs.get(
+                "email_html", api_settings.PASSWORDLESS_EMAIL_TOKEN_HTML_TEMPLATE_NAME
+            )
 
             # Inject context if user specifies.
-            context = inject_template_context({'callback_token': email_token.key, })
-            html_message = loader.render_to_string(email_html, context,)
+            context = inject_template_context(
+                {
+                    "callback_token": email_token.key,
+                }
+            )
+            html_message = loader.render_to_string(
+                email_html,
+                context,
+            )
             send_mail(
                 email_subject,
                 email_plaintext % email_token.key,
                 api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS,
                 [getattr(user, api_settings.PASSWORDLESS_USER_EMAIL_FIELD_NAME)],
                 fail_silently=False,
-                html_message=html_message,)
+                html_message=html_message,
+            )
 
         else:
-            logger.debug("Failed to send token email. Missing PASSWORDLESS_EMAIL_NOREPLY_ADDRESS.")
+            logger.debug(
+                "Failed to send token email. Missing PASSWORDLESS_EMAIL_NOREPLY_ADDRESS."
+            )
             return False
         return True
 
     except Exception as e:
-        logger.debug("Failed to send token email to user: %d."
-                  "Possibly no email on user object. Email entered was %s" %
-                  (user.id, getattr(user, api_settings.PASSWORDLESS_USER_EMAIL_FIELD_NAME)))
+        logger.debug(
+            "Failed to send token email to user: %d."
+            "Possibly no email on user object. Email entered was %s"
+            % (user.id, getattr(user, api_settings.PASSWORDLESS_USER_EMAIL_FIELD_NAME))
+        )
         logger.debug(e)
         return False
 
@@ -169,41 +199,52 @@ def send_sms_with_callback_token(user, mobile_token, **kwargs):
         # even if you have suppression on– you must provide a number if you have mobile selected.
         if api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER is None:
             return False
-            
+
         return True
-    
-    base_string = kwargs.get('mobile_message', api_settings.PASSWORDLESS_MOBILE_MESSAGE)
+
+    base_string = kwargs.get("mobile_message", api_settings.PASSWORDLESS_MOBILE_MESSAGE)
 
     try:
         if api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER:
             # We need a sending number to send properly
 
             from twilio.rest import Client
-            twilio_client = Client(os.environ['TWILIO_ACCOUNT_SID'], os.environ['TWILIO_AUTH_TOKEN'])
+
+            twilio_client = Client(
+                os.environ["TWILIO_ACCOUNT_SID"], os.environ["TWILIO_AUTH_TOKEN"]
+            )
 
             to_number = getattr(user, api_settings.PASSWORDLESS_USER_MOBILE_FIELD_NAME)
-            if to_number.__class__.__name__ == 'PhoneNumber':
+            if to_number.__class__.__name__ == "PhoneNumber":
                 to_number = to_number.__str__()
 
             twilio_client.messages.create(
                 body=base_string % mobile_token.key,
                 to=to_number,
-                from_=api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER
+                from_=api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER,
             )
             return True
         else:
-            logger.debug("Failed to send token sms. Missing PASSWORDLESS_MOBILE_NOREPLY_NUMBER.")
+            logger.debug(
+                "Failed to send token sms. Missing PASSWORDLESS_MOBILE_NOREPLY_NUMBER."
+            )
             return False
     except ImportError:
         logger.debug("Couldn't import Twilio client. Is twilio installed?")
         return False
     except KeyError:
-        logger.debug("Couldn't send SMS."
-                  "Did you set your Twilio account tokens and specify a PASSWORDLESS_MOBILE_NOREPLY_NUMBER?")
+        logger.debug(
+            "Couldn't send SMS."
+            "Did you set your Twilio account tokens and specify a PASSWORDLESS_MOBILE_NOREPLY_NUMBER?"
+        )
     except Exception as e:
-        logger.debug("Failed to send token SMS to user: {}. "
-                  "Possibly no mobile number on user object or the twilio package isn't set up yet. "
-                  "Number entered was {}".format(user.id, getattr(user, api_settings.PASSWORDLESS_USER_MOBILE_FIELD_NAME)))
+        logger.debug(
+            "Failed to send token SMS to user: {}. "
+            "Possibly no mobile number on user object or the twilio package isn't set up yet. "
+            "Number entered was {}".format(
+                user.id, getattr(user, api_settings.PASSWORDLESS_USER_MOBILE_FIELD_NAME)
+            )
+        )
         logger.debug(e)
         return False
 


### PR DESCRIPTION
Filter for is_active=True when looking up existing demo user tokens, so a new token is created after the previous one was deactivated.