### PR TITLE
Fix demo user static OTP being permanently invalidated

### DIFF
--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -210,13 +210,14 @@ class CallbackTokenAuthSerializer(AbstractBaseCallbackTokenSerializer):
             user = User.objects.get(**{alias_type+'__iexact': alias})
 
 
-            #increment the attempt
-            token = CallbackToken.objects.filter(**{'user': user,
-                                                 'type': CallbackToken.TOKEN_TYPE_AUTH,
-                                                 'is_active': True}).first()
+            # increment the attempt only on a wrong token, demo users exempt
+            if user.pk not in api_settings.PASSWORDLESS_DEMO_USERS.keys():
+                token = CallbackToken.objects.filter(**{'user': user,
+                                                     'type': CallbackToken.TOKEN_TYPE_AUTH,
+                                                     'is_active': True}).first()
 
-            if token:
-                token.increment_attempts()
+                if token and token.key != callback_token:
+                    token.increment_attempts()
 
             validate_token_age(callback_token)
 

--- a/drfpasswordless/signals.py
+++ b/drfpasswordless/signals.py
@@ -31,6 +31,10 @@ def check_unique_tokens(sender, instance, **kwargs):
     Note that here we've decided keys are unique even across auth and validation.
     We could consider relaxing this in the future as well by filtering on the instance.type.
     """
+    if instance.user_id in api_settings.PASSWORDLESS_DEMO_USERS.keys():
+        # a demo user's static key is meant to repeat
+        return
+
     if instance._state.adding:
         # save is called on a token to create it in the db
         # before creating check whether a token with the same key exists

--- a/drfpasswordless/utils.py
+++ b/drfpasswordless/utils.py
@@ -40,13 +40,17 @@ def create_callback_token_for_user(user, alias_type, token_type):
     alias_type_u = alias_type.upper()
     to_alias_field = getattr(api_settings, f'PASSWORDLESS_USER_{alias_type_u}_FIELD_NAME')
     if user.pk in api_settings.PASSWORDLESS_DEMO_USERS.keys():
-        token = CallbackToken.objects.filter(user=user).first()
+        demo_key = api_settings.PASSWORDLESS_DEMO_USERS[user.pk]
+        token = CallbackToken.objects.filter(user=user,
+                                             key=demo_key,
+                                             type=token_type,
+                                             is_active=True).first()
         if token:
             return token
         else:
             return CallbackToken.objects.create(
                 user=user,
-                key=api_settings.PASSWORDLESS_DEMO_USERS[user.pk],
+                key=demo_key,
                 to_alias_type=alias_type_u,
                 to_alias=getattr(user, to_alias_field),
                 type=token_type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def pytest_configure():
             'django.contrib.messages',
             'django.contrib.staticfiles',
             'rest_framework',
-            'rest_framework.authtoken',
+            'drfpasswordless.authtoken',
             'drfpasswordless',
             'tests',
         ),

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,5 +1,5 @@
 from rest_framework import status
-from rest_framework.authtoken.models import Token
+from drfpasswordless.authtoken.models import Token
 from rest_framework.test import APITestCase
 
 from django.contrib.auth import get_user_model
@@ -240,8 +240,8 @@ class MobileSignUpCallbackTokenTests(APITestCase):
         api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER = DEFAULTS['PASSWORDLESS_MOBILE_NOREPLY_NUMBER']
 
 
-def dummy_token_creator(user):
-    token = Token.objects.create(key="dummy", user=user)
+def dummy_token_creator(user, device_id=None, device_type=None):
+    token = Token.objects.create(key="dummy", user=user, device_id=device_id, device_type=device_type)
     return (token, True)
 
 
@@ -364,4 +364,117 @@ class MobileLoginCallbackTokenTests(APITestCase):
         api_settings.PASSWORDLESS_TEST_SUPPRESSION = DEFAULTS['PASSWORDLESS_TEST_SUPPRESSION']
         api_settings.PASSWORDLESS_AUTH_TYPES = DEFAULTS['PASSWORDLESS_AUTH_TYPES']
         api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER = DEFAULTS['PASSWORDLESS_MOBILE_NOREPLY_NUMBER']
+        self.user.delete()
+
+
+class DemoUserStaticTokenTests(APITestCase):
+    """
+    A demo user's static PIN has to keep working login after login.
+    """
+
+    static_token = '123456'
+
+    def setUp(self):
+        api_settings.PASSWORDLESS_AUTH_TYPES = ['EMAIL']
+        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS = 'noreply@example.com'
+
+        self.email = 'demo@example.com'
+        self.url = reverse('drfpasswordless:auth_email')
+        self.challenge_url = reverse('drfpasswordless:auth_token')
+
+        self.email_field_name = api_settings.PASSWORDLESS_USER_EMAIL_FIELD_NAME
+        self.user = User.objects.create(**{self.email_field_name: self.email})
+
+        api_settings.PASSWORDLESS_DEMO_USERS = {self.user.pk: self.static_token}
+
+    def request_token(self):
+        return self.client.post(self.url, {'email': self.email})
+
+    def login(self, token):
+        return self.client.post(self.challenge_url, {'email': self.email, 'token': token})
+
+    def test_demo_user_static_token_is_issued(self):
+        self.assertEqual(self.request_token().status_code, status.HTTP_200_OK)
+
+        callback_token = CallbackToken.objects.filter(user=self.user, is_active=True).first()
+        self.assertEqual(callback_token.key, self.static_token)
+
+    def test_demo_user_can_log_in_repeatedly_with_static_token(self):
+        # more logins than the max-attempts cutoff
+        for _ in range(6):
+            self.assertEqual(self.request_token().status_code, status.HTTP_200_OK)
+            self.assertEqual(self.login(self.static_token).status_code, status.HTTP_200_OK)
+
+    def test_demo_user_static_token_survives_wrong_attempts(self):
+        self.assertEqual(self.request_token().status_code, status.HTTP_200_OK)
+
+        for _ in range(5):
+            self.assertEqual(self.login('000000').status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.assertEqual(self.login(self.static_token).status_code, status.HTTP_200_OK)
+
+    def test_demo_user_gets_a_fresh_token_when_the_old_one_is_spent(self):
+        self.assertEqual(self.request_token().status_code, status.HTTP_200_OK)
+        CallbackToken.objects.filter(user=self.user).update(is_active=False, attempts=4)
+
+        self.assertEqual(self.request_token().status_code, status.HTTP_200_OK)
+        self.assertEqual(self.login(self.static_token).status_code, status.HTTP_200_OK)
+
+    def tearDown(self):
+        api_settings.PASSWORDLESS_DEMO_USERS = DEFAULTS['PASSWORDLESS_DEMO_USERS']
+        api_settings.PASSWORDLESS_AUTH_TYPES = DEFAULTS['PASSWORDLESS_AUTH_TYPES']
+        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS = DEFAULTS['PASSWORDLESS_EMAIL_NOREPLY_ADDRESS']
+        self.user.delete()
+
+
+class CallbackTokenAttemptsTests(APITestCase):
+    """
+    The max-attempts limit should only count wrong tokens.
+    """
+
+    def setUp(self):
+        api_settings.PASSWORDLESS_AUTH_TYPES = ['EMAIL']
+        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS = 'noreply@example.com'
+
+        self.email = 'aaron@example.com'
+        self.url = reverse('drfpasswordless:auth_email')
+        self.challenge_url = reverse('drfpasswordless:auth_token')
+
+        self.email_field_name = api_settings.PASSWORDLESS_USER_EMAIL_FIELD_NAME
+        self.user = User.objects.create(**{self.email_field_name: self.email})
+
+    def active_token_key(self):
+        return CallbackToken.objects.filter(user=self.user, is_active=True).first().key
+
+    def wrong_token(self, callback_token):
+        return '000000' if callback_token != '000000' else '111111'
+
+    def login(self, token):
+        return self.client.post(self.challenge_url, {'email': self.email, 'token': token})
+
+    def test_correct_token_does_not_count_as_an_attempt(self):
+        self.assertEqual(self.client.post(self.url, {'email': self.email}).status_code, status.HTTP_200_OK)
+        callback_token = self.active_token_key()
+
+        for _ in range(3):
+            self.assertEqual(self.login(self.wrong_token(callback_token)).status_code,
+                             status.HTTP_400_BAD_REQUEST)
+
+        self.assertEqual(self.login(callback_token).status_code, status.HTTP_200_OK)
+
+    def test_token_is_deactivated_after_too_many_wrong_attempts(self):
+        self.assertEqual(self.client.post(self.url, {'email': self.email}).status_code, status.HTTP_200_OK)
+        callback_token = self.active_token_key()
+
+        for _ in range(4):
+            self.assertEqual(self.login(self.wrong_token(callback_token)).status_code,
+                             status.HTTP_400_BAD_REQUEST)
+
+        # the limit still applies, even to the right code
+        self.assertEqual(self.login(callback_token).status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(CallbackToken.objects.get(key=callback_token).is_active)
+
+    def tearDown(self):
+        api_settings.PASSWORDLESS_AUTH_TYPES = DEFAULTS['PASSWORDLESS_AUTH_TYPES']
+        api_settings.PASSWORDLESS_EMAIL_NOREPLY_ADDRESS = DEFAULTS['PASSWORDLESS_EMAIL_NOREPLY_ADDRESS']
         self.user.delete()


### PR DESCRIPTION
The attempts counter added for max-attempt enforcement burned down on successful logins too, which broke demo users specifically: they reuse a single static token row across every login, so its attempts accumulated until the token deactivated itself mid-login, and the demo branch of create_callback_token_for_user handed the dead row back on every resend without an is_active filter. The static OTP was then rejected forever with "Invalid OTP or OTP may be expired" and only a DB edit could recover it.

- serializers: count an attempt only when the submitted token is wrong, and exempt demo users, whose token is a static configured PIN.
- utils: match the demo token on key, type and is_active so a spent one is replaced by a fresh token carrying the same static key, instead of being resurrected as an unusable row. Scoping by type also stops an AUTH request from being served the demo user's VERIFY token, which the type-agnostic lookup could do since ordering is by UUID pk.
- signals: skip the unique-key check for demo users, since their key is meant to repeat and regenerating it would break the static OTP.

Also fixes test wiring that predates this change: conftest registered rest_framework.authtoken rather than this fork's drfpasswordless.authtoken, which left its Token model abstract, and dummy_token_creator hadn't been updated for device_id/device_type. The suite went from 9 failures to green.